### PR TITLE
Making setup-script generic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-Dead simple script to setup my new Mac:
+# Dead simple script to setup my new Mac
 
-```shell
-curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh | sh
-```
+### Installation
+- Paste the following command on your command line
+    ```shell
+    $curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh $1 $2 | sh
+    ```
+- Replace $1 and $2 with the following credentials of your GitHub account
+    - ```GitHub Username```
+    - ```GitHub email```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ### Installation
 - Paste the following command on your command line
 
-    ```curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh | bash -s $1 $2
+    ```shell
+    $ curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh | bash -s $1 $2
     ```
 
 - Replace $1 and $2 with the following credentials of your GitHub account

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@
     $curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh $1 $2 | sh
     ```
 
-- Replace \$1 and \$2 with the following credentials of your GitHub account
+- Replace $1 and $2 with the following credentials of your GitHub account
     - ```GitHub Username```
     - ```GitHub email```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ### Installation
 - Paste the following command on your command line
+
     ```shell
     $curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh $1 $2 | sh
     ```
-- Replace $1 and $2 with the following credentials of your GitHub account
+
+- Replace \$1 and \$2 with the following credentials of your GitHub account
     - ```GitHub Username```
     - ```GitHub email```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ### Installation
 - Paste the following command on your command line
 
-    ```shell
-    $curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh $1 $2 | sh
+    ```curl -sL https://raw.githubusercontent.com/codingnirvana/mac-setup-script/master/setup.sh | bash -s $1 $2
     ```
 
 - Replace $1 and $2 with the following credentials of your GitHub account

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ casks=(
   intellij-idea-ce
   iterm2
   kindle
-  picasa  
+  picasa
   java
   slack
   screenhero
@@ -49,7 +49,7 @@ casks=(
   todoist
   teleport
   vlc
-  tunnelblick	
+  tunnelblick
 )
 
 pips=(
@@ -146,7 +146,8 @@ echo "Setting git defaults ..."
 git config --global rerere.enabled true
 git config --global branch.autosetuprebase always
 git config --global credential.helper osxkeychain
-git config --global user.email mrajesh123@gmail.com
+git config --global user.name $1
+git config --global user.email $2
 
 echo "Upgrading ..."
 pip install --upgrade setuptools


### PR DESCRIPTION
Hi @codingnirvana 

I have tried improving the script by making it more generic in terms of setting up GitHub credentials through this script. Following are the changes :
- Earlier the email and username was customized to your own account, now the script takes the _github username_ and _github email_ as arguments.
- Improved the _README.md_ file with descriptions for the above changes

Hope this helps 
